### PR TITLE
Fix Gemfile to fix local website build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
-gem 'nokogiri'
-gem 'rack', '~> 2.2.4'
-gem 'rspec'
+gem 'github-pages', group: :jekyll_plugins
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
A recent [PR](https://github.com/cs182sp22/cs182sp22.github.io/commit/d1cadb638ba5b763bceec3964c065ca710cfaaad) broke the ability to locally build the website. This PR fixes it.
```
# Before this fix
$ bundle exec jekyll serve
C:/Ruby33-x64/lib/ruby/gems/3.3.0/gems/bundler-2.5.17/lib/bundler/rubygems_integration.rb:265:in `block in replace_bin_path': can't find executable jekyll for gem jekyll. jekyll is not currently included in the bundle, perhaps you meant to add it to your Gemfile? (Gem::Exception)
        from C:/Ruby33-x64/lib/ruby/gems/3.3.0/gems/bundler-2.5.17/lib/bundler/rubygems_integration.rb:293:in `block in replace_bin_path'
        from C:/Ruby33-x64/bin/jekyll:32:in `<main>'
# With this fix
$ bundle exec jekyll serve
Configuration file: C:/Users/Eric/teaching/datac182fa24.github.io/_config.yml
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
            Source: C:/Users/Eric/teaching/datac182fa24.github.io
       Destination: C:/Users/Eric/teaching/datac182fa24.github.io/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
      Remote Theme: Using theme pmarsceill/just-the-docs
                    done in 4.985 seconds.
  Please add the following to your Gemfile to avoid polling for changes:
    gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 Auto-regeneration: enabled for 'C:/Users/Eric/teaching/datac182fa24.github.io'
    Server address: http://127.0.0.1:4000/
  Server running... press ctrl-c to stop.
```